### PR TITLE
Fix cilium cli output condition to be compatible with cilium cli 0.15.22

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,7 +69,7 @@
   environment:
     KUBECONFIG: "{{ cilium_kubeconfig_path }}"
   register: cilium_install
-  when: '"Unable to obtain cilium version, no cilium pods found in namespace" in cilium_running_version.stdout'
+  when: '"Unable to obtain cilium version" in cilium_running_version.stdout'
 
 - name: upgrade/downgrade cilium or change cilium config
   ansible.builtin.shell:


### PR DESCRIPTION
# Pull Request Description
Fixed cilium install condition (checking if Cilium is installed or not) to align with newer versions of cilium cli


## Change type

- [X] Bug fix (non-breaking change which fixes a specific issue)
- [ ] New feature (non-breaking change adding new functionality)
- [ ] Breaking change (fix or feature that potentially causes existing functionality to fail)
- [ ] Change that does not affect Ansible Role code (Github Actions Workflow, Documentation, or similair)

## How was this tested?
Tested on test and prod clusters running rke2 and cilium alike.