### PR TITLE
Secure permissions for Cilium config

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,6 +50,7 @@
   ansible.builtin.template:
     src: "cilium-config.j2"
     dest: "{{ cilium_config_file_path }}"
+    mode: '0600'
   register: cilium_config
 
 - name: check cilium version


### PR DESCRIPTION
# Pull Request Description
Permissions for Cilium configuration file should be locked down since it potentially contains security sensitive information.

## Change type

- [X] Bug fix (non-breaking change which fixes a specific issue)
- [ ] New feature (non-breaking change adding new functionality)
- [ ] Breaking change (fix or feature that potentially causes existing functionality to fail)
- [ ] Change that does not affect Ansible Role code (Github Actions Workflow, Documentation, or similair)
