### PR TITLE
Add Cilium config options (rollout on config update+update strategy) + add restart cilium on config change condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,19 @@ Ansible role to install/upgrade/downgrade/change Cillium (config) on k8s cluster
 
 # Requirements
 - Ansible 2.10 or later
+- Kubernetes cluster with no CNI or Cilium installed
 
 # Tested on
 - Ubuntu 20.04 LTS
 - Ubuntu 22.04 LTS
 
+  NOTE: Should work on all Linux/k8s distributions
+
 # Role Variables
 All settable variables with explanations and links are located in the defaults/main.yml
 
 ## TODO
-- Create Action to publish to Anisble Galaxy
+- Create Action to publish to Ansible Galaxy
 - Write Molecule tests
 - Create Action to run Molecule tests
 - Create CI

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,9 @@ cilium_kubectl_bin_path: kubectl
 # Kubectl config path
 cilium_kubeconfig_path: ~/.kube/config
 
+# Restart cilium operator and agents on config change
+cilium_restart_on_config_change: false
+
 # Cilium specific config
 
 # Configure the kube-proxy replacement in Cilium BPF datapath

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 cilium_config_file_path: "/home/{{ ansible_user }}/cilium-config.yml"
 
 # Cilium version to be installed/upgraded/downgraded
-cilium_version: '1.14.3'
+cilium_version: "1.14.3"
 
 # Cilium CLI version to be installed/upgraded/downgraded
 # If left blank latest version of Cilium CLI will be determined and installed
@@ -36,7 +36,7 @@ cilium_kube_proxy_replacement: false
 #   priorityClassName: "high-priority"
 
 # (string) Kubernetes service host
-cilium_k8s_service_host: ''
+cilium_k8s_service_host: ""
 
 # (string) Kubernetes service port
 cilium_k8s_service_port: "6443"
@@ -170,9 +170,6 @@ cilium_l7_proxy: true
 #   ui:
 #     enabled: true
 
-# (optional) Additional options to pass to cilium config in yaml format
-# cilium_additional_options:
-
 # Install Hubble cli
 cilium_install_hubble_cli: true
 
@@ -183,3 +180,16 @@ cilium_hubble_cli_version:
 
 # Hubble CLI binary path
 cilium_hubble_cli_bin_path: /usr/local/bin/hubble
+
+# Roll out cilium agent pods automatically when configmap is updated.
+cilium_rollout_pods_on_update: false
+
+# (optional) Cilium agent update strategy
+# cilium_update_strategy:
+#   updateStrategy:
+#     type: RollingUpdate
+#     rollingUpdate:
+#       maxUnavailable: 2
+
+# (optional) Additional options to pass to cilium config in yaml format
+# cilium_additional_options:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -92,7 +92,7 @@
 
 - name: wait for cilium to be running and ready
   ansible.builtin.shell:
-    cmd: "{{ cilium_cli_bin_path }} status --wait"
+    cmd: "{{ cilium_cli_bin_path }} status --wait --wait-duration 10m"
   environment:
     KUBECONFIG: "{{ cilium_kubeconfig_path }}"
   when: cilium_install.changed or cilium_upgrade.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,7 +86,7 @@
     {{ cilium_kubectl_bin_path }} --kubeconfig {{ cilium_kubeconfig_path }} -n kube-system rollout restart daemonset/cilium
   register: cilium_restart
   when:
-  - cilium_upgrade.changed
+  - cilium_config.changed
   - cilium_install.changed == false
   - cilium_restart_on_config_change | bool
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,21 +80,21 @@
   - cilium_version not in cilium_running_version.stdout or cilium_config.changed
   - cilium_install.changed == false
 
-- name: restart cilium
-  ansible.builtin.shell: |
-    {{ cilium_kubectl_bin_path }} --kubeconfig {{ cilium_kubeconfig_path }} -n kube-system rollout restart deployment/cilium-operator
-    {{ cilium_kubectl_bin_path }} --kubeconfig {{ cilium_kubeconfig_path }} -n kube-system rollout restart daemonset/cilium
-  register: cilium_restart
-  when:
-  - cilium_config.changed
-  - cilium_install.changed == false
+# - name: restart cilium
+#   ansible.builtin.shell: |
+#     {{ cilium_kubectl_bin_path }} --kubeconfig {{ cilium_kubeconfig_path }} -n kube-system rollout restart deployment/cilium-operator
+#     {{ cilium_kubectl_bin_path }} --kubeconfig {{ cilium_kubeconfig_path }} -n kube-system rollout restart daemonset/cilium
+#   register: cilium_restart
+#   when:
+#   - cilium_config.changed
+#   - cilium_install.changed == false
 
 - name: wait for cilium to be running and ready
   ansible.builtin.shell:
     cmd: "{{ cilium_cli_bin_path }} status --wait"
   environment:
     KUBECONFIG: "{{ cilium_kubeconfig_path }}"
-  when: cilium_install.changed or cilium_upgrade.changed or cilium_restart.changed
+  when: cilium_install.changed or cilium_upgrade.changed # or cilium_restart.changed
 
 - name: install hubble cli
   ansible.builtin.include_tasks:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,21 +80,22 @@
   - cilium_version not in cilium_running_version.stdout or cilium_config.changed
   - cilium_install.changed == false
 
-# - name: restart cilium
-#   ansible.builtin.shell: |
-#     {{ cilium_kubectl_bin_path }} --kubeconfig {{ cilium_kubeconfig_path }} -n kube-system rollout restart deployment/cilium-operator
-#     {{ cilium_kubectl_bin_path }} --kubeconfig {{ cilium_kubeconfig_path }} -n kube-system rollout restart daemonset/cilium
-#   register: cilium_restart
-#   when:
-#   - cilium_config.changed
-#   - cilium_install.changed == false
+- name: restart cilium
+  ansible.builtin.shell: |
+    {{ cilium_kubectl_bin_path }} --kubeconfig {{ cilium_kubeconfig_path }} -n kube-system rollout restart deployment/cilium-operator
+    {{ cilium_kubectl_bin_path }} --kubeconfig {{ cilium_kubeconfig_path }} -n kube-system rollout restart daemonset/cilium
+  register: cilium_restart
+  when:
+  - cilium_upgrade.changed
+  - cilium_install.changed == false
+  - cilium_restart_on_config_change | bool
 
 - name: wait for cilium to be running and ready
   ansible.builtin.shell:
     cmd: "{{ cilium_cli_bin_path }} status --wait"
   environment:
     KUBECONFIG: "{{ cilium_kubeconfig_path }}"
-  when: cilium_install.changed or cilium_upgrade.changed # or cilium_restart.changed
+  when: cilium_install.changed or cilium_upgrade.changed
 
 - name: install hubble cli
   ansible.builtin.include_tasks:

--- a/templates/cilium-config.j2
+++ b/templates/cilium-config.j2
@@ -78,6 +78,12 @@ ipMasqAgent: {{ cilium_ip_masq_agent_config }}
 hubble: {{ cilium_hubble_config }}
 {% endif %}
 
+rollOutCiliumPods: {{ cilium_rollout_pods_on_update }}
+
+{% if cilium_update_strategy is defined %}
+updateStrategy: {{ cilium_update_strategy }}
+{% endif %}
+
 {% if cilium_additional_options is defined %}
 {{ cilium_additional_options | to_nice_yaml }}
 {% endif %}


### PR DESCRIPTION
# Pull Request Description
- Added Cilium config option for rolling out a Cilium agent daemon set restart when Cilium configmap is updated
- Added Cilium config option for defining/changing Cilium agent daemon set update strategy 
- Added option to force a restart of Cilium Operators and Agents on config change using an Ansible task

## Change type

- [ ] Bug fix (non-breaking change which fixes a specific issue)
- [x] New feature (non-breaking change adding new functionality)
- [ ] Breaking change (fix or feature that potentially causes existing functionality to fail)
- [ ] Change that does not affect Ansible Role code (Github Actions Workflow, Documentation, or similair)

## How was this tested?
Ubuntu 20.04/22.04 + RKE2 v1.27.10+rke2r1