### PR TITLE
Add settable cilium status wait duration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,9 @@ cilium_kubeconfig_path: ~/.kube/config
 # Restart cilium operator and agents on config change
 cilium_restart_on_config_change: false
 
+# Duration to wait for cilium status to report success
+cilium_status_wait_duration: 10m
+
 # Cilium specific config
 
 # Configure the kube-proxy replacement in Cilium BPF datapath

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -115,7 +115,7 @@
     - cilium_restart_on_config_change | bool
 
 - name: Wait for Cilium to be running and ready
-  ansible.builtin.command: "{{ cilium_cli_bin_path }} status --wait --wait-duration 10m"
+  ansible.builtin.command: "{{ cilium_cli_bin_path }} status --wait --wait-duration {{ cilium_status_wait_duration }}"
   environment:
     KUBECONFIG: "{{ cilium_kubeconfig_path }}"
   changed_when: true


### PR DESCRIPTION
# Pull Request Description
Added variable to set wait duration for the cilium status command to report success, previously was hardcoded to 10m, so i added the default of 10m, to keep the default behaviour consistent.

## Change type
- [ ] Bug fix (non-breaking change which fixes a specific issue)
- [x] New feature (non-breaking change adding new functionality)
- [ ] Breaking change (fix or feature that potentially causes existing functionality to fail)
- [ ] Change that does not affect Ansible Role code (Github Actions Workflow, Documentation, or similair)